### PR TITLE
Fix dependencies version bounds

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": "> 4.4.0 < 9.0.0"
+      "version_requirement": ">= 4.4.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": "> 1.1.1 < 8.0.0"
+      "version_requirement": ">= 1.1.1 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Dependencies are ofter in the form `>= a.b.c < x.y.z` (first version providing
an used feature and future major version that might break the module).
Anything else is generally a typo.  This seems to be the case here.
