### PR TITLE
Allow puppetlabs/stdlib 9.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,13 +24,9 @@ class riemann (
   $reload_command,
   $validate_cmd,
   $test_before_reload,
-  $pubsub_var,
+  Pattern['^::'] $pubsub_var,
   $debug,
 ) {
-
-  # validate parameters here
-  validate_re($pubsub_var, '^::','please specify only absolute top scope variable names')
-
   class { 'riemann::install': }
   -> class { 'riemann::config': }
   ~> class { 'riemann::service': }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.4.0 < 9.0.0"
+      "version_requirement": ">= 4.4.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Puppet 4 introduced data type that replace the legacy `validate_*()`
functions.  These deprecated functions where removed from stdlib while
adding support for Puppet 8.

Time to get rid of it.  The module already requires Puppet 4+ so this is
not a breaking change.
